### PR TITLE
Add support for Postcode API v3

### DIFF
--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -28,14 +28,14 @@ class pyPostcodeException(Exception):
 
 class Api(object):
 
-    def __init__(self, api_key, api_version=(2, 0, 0)):
+    def __init__(self, api_key, api_version=(3, 0, 0)):
         if api_key is None or api_key is '':
             raise pyPostcodeException(
                 0, "Please request an api key on http://postcodeapi.nu")
 
         self.api_key = api_key
         self.api_version = api_version
-        if api_version >= (2, 0, 0):
+        if (2, 0, 0) <= api_version < (3, 0, 0):
             self.url = 'https://postcode-api.apiwise.nl'
         else:
             self.url = 'http://api.postcodeapi.nu'
@@ -58,9 +58,7 @@ class Api(object):
         headers = {
             "Accept": "application/json",
             "Accept-Language": "en",
-            # this is the v1 api
-            "Api-Key": self.api_key,
-            # this is the v2 api
+            # this is the v2 and v3 api key
             "X-Api-Key": self.api_key,
         }
 
@@ -77,28 +75,30 @@ class Api(object):
             resultdata = resultdata.decode("utf-8")  # for Python 3
         jsondata = json.loads(resultdata)
 
-        if self.api_version >= (2, 0, 0):
+        if (2, 0, 0) <= self.api_version < (3, 0, 0):
             data = jsondata.get('_embedded', {}).get('addresses', [])
             if data:
                 data = data[0]
             else:
                 data = None
         else:
-            data = jsondata['resource']
+            data = jsondata
 
         return data
 
     def getaddress(self, postcode, house_number=None):
-        if house_number is None:
-            house_number = ''
-
-        if self.api_version >= (2, 0, 0):
-            path = '/v2/addresses/?postcode={0}&number={1}'
+        if (2, 0, 0) <= self.api_version < (3, 0, 0):
+            path = '/v2/addresses/?postcode={0}'
+            if house_number is not None:
+                path += '&number={1}'
+            resource = ResourceV2
         else:
-            path = '/{0}/{1}'
+            path = '/v3/lookup/{postcode}/{house_number}'
+            if house_number is not None:
+                path += '/{house_number}'
+            resource = ResourceV3
         path = path.format(
-            str(postcode),
-            str(house_number))
+            postcode=str(postcode), house_number=str(house_number))
 
         try:
             data = self.request(path)
@@ -113,15 +113,32 @@ class Api(object):
             data = None
 
         if data is not None:
-            return Resource(data)
+            return resource(data)
         else:
             return False
 
 
-class Resource(object):
+class Resource:
 
     def __init__(self, data):
         self._data = data
+
+    def not_implemented(self):
+        return NotImplemented
+
+    street = property(not_implemented)
+    house_number = property(not_implemented)
+    postcode = property(not_implemented)
+    town = property(not_implemented)
+    municipality = property(not_implemented)
+    province = property(not_implemented)
+    latitude = property(not_implemented)
+    longitude = property(not_implemented)
+    x = property(not_implemented)
+    y = property(not_implemented)
+
+
+class ResourceV2(Resource):
 
     @property
     def street(self):
@@ -184,3 +201,52 @@ class Resource(object):
         if self._data.get('y'):
             return self._data.get('y')
         return self._get_geo_coordinates('rd')[1]
+
+
+class ResourceV3(Resource):
+
+    @property
+    def street(self):
+        return self._data['street']
+
+    @property
+    def house_number(self):
+        return self._data.get('number')
+
+    @property
+    def postcode(self):
+        return self._data.get('postcode')
+
+    @property
+    def city(self):
+        return self._data.get('city')
+
+    @property
+    def municipality(self):
+        return self._data.get('municipality')
+
+    @property
+    def province(self):
+        return self._data.get('province')
+
+    @property
+    def coordinates(self):
+        return self._data.get('location', {}).get('coordinates')
+
+    @property
+    def latitude(self):
+        coordinates = self.coordinates
+        return coordinates and coordinates[1] or None
+
+    @property
+    def longitude(self):
+        coordinates = self.coordinates
+        return coordinates and coordinates[0] or None
+
+    @property
+    def x(self):
+        return self.longitude
+
+    @property
+    def y(self):
+        return self.latitude

--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -137,6 +137,7 @@ class Resource:
     longitude = property(not_implemented)
     x = property(not_implemented)
     y = property(not_implemented)
+    coordinates = property(not_implemented)
 
 
 class ResourceV2(Resource):

--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -125,7 +125,7 @@ class Resource:
         self._data = data
 
     def not_implemented(self):
-        return NotImplemented
+        raise NotImplementedError
 
     street = property(not_implemented)
     house_number = property(not_implemented)

--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -14,6 +14,7 @@ except ImportError:
 
 import json
 import logging
+from warnings import warn
 
 
 __version__ = '0.5'
@@ -220,6 +221,12 @@ class ResourceV3(Resource):
     @property
     def city(self):
         return self._data.get('city')
+
+    @property
+    def town(self):
+        warn('Use the attribute "city" instead',
+             DeprecationWarning, stacklevel=2)
+        return self.city
 
     @property
     def municipality(self):

--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -94,9 +94,9 @@ class Api(object):
                 path += '&number={1}'
             resource = ResourceV2
         else:
+            if house_number is None:
+                raise ValueError('"house_number" cannot be None')
             path = '/v3/lookup/{postcode}/{house_number}'
-            if house_number is not None:
-                path += '/{house_number}'
             resource = ResourceV3
         path = path.format(
             postcode=str(postcode), house_number=str(house_number))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+
+from pyPostcode import Api, pyPostcodeException
+
+
+class TestAPI(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api = Api(os.environ.get('POSTCODE_API_KEY'))
+        self.api.url = 'https://sandbox.postcodeapi.nu'
+
+    def test_api_key_is_required(self):
+        with self.assertRaises(pyPostcodeException):
+            Api('')
+
+    def test_api(self):
+        results = self.api.getaddress('6545CA', 29)
+        latitude = 51.841554
+        longitude = 5.8696099
+
+        self.assertEqual(results.postcode, '6545CA')
+        self.assertEqual(results.house_number, 29)
+        self.assertEqual(results.street, 'Waldeck Pyrmontsingel')
+        self.assertEqual(results.city, 'Nijmegen')
+        self.assertEqual(results.municipality, 'Nijmegen')
+        self.assertEqual(results.province, 'Gelderland')
+        self.assertEqual(results.coordinates, [longitude, latitude])
+        self.assertEqual(results.x, longitude)
+        self.assertEqual(results.longitude, longitude)
+        self.assertEqual(results.y, latitude)
+        self.assertEqual(results.latitude, latitude)


### PR DESCRIPTION
Closes #17 

- Adds support for Postcode API v3 https://www.postcodeapi.nu/docs/v3/#operation/lookup
- Keeps support for Postcode API v2 https://www.postcodeapi.nu/docs/v2/
- Deprecates support for Postcode API v1 (if any)