### PR TITLE
Use HTTPS, fix v2 API, fix error logging

### DIFF
--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -42,7 +42,7 @@ class Api(object):
             self.url = 'https://api.postcodeapi.nu'
 
     def handleresponseerror(self, status):
-        if status == 401:
+        if status in [401, 403]:
             msg = "Access denied! Api-key missing or invalid"
         elif status == 404:
             msg = "No result found"
@@ -89,9 +89,9 @@ class Api(object):
 
     def getaddress(self, postcode, house_number=None):
         if (2, 0, 0) <= self.api_version < (3, 0, 0):
-            path = '/v2/addresses/?postcode={0}'
+            path = '/v2/addresses/?postcode={postcode}'
             if house_number is not None:
-                path += '&number={1}'
+                path += '&number={house_number}'
             resource = ResourceV2
         else:
             if house_number is None:

--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -39,7 +39,7 @@ class Api(object):
         if (2, 0, 0) <= api_version < (3, 0, 0):
             self.url = 'https://postcode-api.apiwise.nl'
         else:
-            self.url = 'http://api.postcodeapi.nu'
+            self.url = 'https://api.postcodeapi.nu'
 
     def handleresponseerror(self, status):
         if status == 401:

--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -9,8 +9,9 @@ pyPostcode is an api wrapper for http://postcodeapi.nu
 
 try:
     from urllib.request import urlopen, Request  # for Python 3
+    from urllib.error import HTTPError
 except ImportError:
-    from urllib2 import urlopen, Request  # for Python 2
+    from urllib2 import urlopen, Request, HTTPError  # for Python 2
 
 import json
 import logging
@@ -63,9 +64,12 @@ class Api(object):
             "X-Api-Key": self.api_key,
         }
 
-        result = urlopen(Request(
-            self.url + path, headers=headers,
-        ))
+        try:
+            result = urlopen(Request(
+                self.url + path, headers=headers,
+            ))
+        except HTTPError as err:
+            self.handleresponseerror(err.code)
 
         if result.getcode() != 200:
             self.handleresponseerror(result.getcode())

--- a/pyPostcode/__init__.py
+++ b/pyPostcode/__init__.py
@@ -30,7 +30,7 @@ class pyPostcodeException(Exception):
 class Api(object):
 
     def __init__(self, api_key, api_version=(3, 0, 0)):
-        if api_key is None or api_key is '':
+        if not api_key:
             raise pyPostcodeException(
                 0, "Please request an api key on http://postcodeapi.nu")
 
@@ -67,7 +67,7 @@ class Api(object):
             self.url + path, headers=headers,
         ))
 
-        if result.getcode() is not 200:
+        if result.getcode() != 200:
             self.handleresponseerror(result.getcode())
 
         resultdata = result.read()


### PR DESCRIPTION
These are small fixes for a few different issues. Mainly:

- It's better to use HTTPS so people can't snoop on the API key and user addresses.

- An earlier commit accidentally broke the formatting of the URL for the v2 API.

- `handleresponseerror()` wasn't being used because it didn't expect an `HTTPError`.